### PR TITLE
Don't prescribe what to do with public key that has wrong length

### DIFF
--- a/draft-ietf-tls-mldsa.md
+++ b/draft-ietf-tls-mldsa.md
@@ -97,7 +97,7 @@ then the signature MUST be computed and verified as specified in
 {{Section 4.4.3 of RFC8446}}, and the corresponding end-entity
 certificate MUST use the corresponding AlgorithmIdentifier from {{schemes}}.
 
-If the signature is of the wrong length, the client MUST
+If the signature is of the wrong length, the verifying peer MUST
 treat this a verification failure, and thus terminate the handshake
 with `decrypt_error` alert.
 
@@ -143,5 +143,6 @@ Thanks to
     Ryan Appel,
     Loganaden Velvindron,
     David Benjamin,
+    Viktor Dukhovni,
     and Nick Sullivan
     for their review and feedback.

--- a/draft-ietf-tls-mldsa.md
+++ b/draft-ietf-tls-mldsa.md
@@ -97,7 +97,7 @@ then the signature MUST be computed and verified as specified in
 {{Section 4.4.3 of RFC8446}}, and the corresponding end-entity
 certificate MUST use the corresponding AlgorithmIdentifier from {{schemes}}.
 
-If the signature or public key is of the wrong length, the client MUST
+If the signature is of the wrong length, the client MUST
 treat this a verification failure, and thus terminate the handshake
 with `decrypt_error` alert.
 
@@ -142,5 +142,6 @@ Thanks to
     Niklas Block,
     Ryan Appel,
     Loganaden Velvindron,
+    David Benjamin,
     and Nick Sullivan
     for their review and feedback.


### PR DESCRIPTION
Suggested by David Benjamin:

    This should delete "or public key". The public key is carried inside
    the certificate. That means questions of the length or contents of
    the public key will be resolved at the X.509 layer, either failing
    in overall X.509 certificate parsing, or in extracting the SPKI
    from the certificate. What alert is sent will depend a lot on exactly
    what is processed in what layer by the application, so I think it
    is best to just not say anything. The signature, on the other hand,
    is delivered directly via TLS, so prescribing the alert is in scope.
    (Even so this sentence is a bit redundant since your signature
    verification function had better check the length as part of the
    process! *shrug*)