### PR TITLE
Fix duplicated 'as follows' in Section 3

### DIFF
--- a/draft-ietf-tls-mldsa.md
+++ b/draft-ietf-tls-mldsa.md
@@ -75,7 +75,7 @@ the negotiation of signature scheme for authentication via the
 `signature_algorithms` and `signature_algorithms_cert` extensions.
 This document maps three new SignatureScheme values for the three
 ML-DSA parameter sets listed in Section 4, Table 1 of {{FIPS204}}
-to the SignatureAlgorithmIdentifiers from {{RFC9881}} as follows as follows.
+to the SignatureAlgorithmIdentifiers from {{RFC9881}} as follows.
 
 | SignatureScheme | FIPS 204  | Signature AlgorithmIdentifier   |
 |-----------------|-----------|----------------------------------------|


### PR DESCRIPTION
Editorial nit from Charlie Kaufman's SECDIR IETF Last Call review:

> First paragraph of section 3: "as follows as follows" should be "as follows"

Removes the duplicated "as follows". No normative changes.