### PR TITLE
Remove duplicate FIPS context note

### DIFF
--- a/draft-ietf-tls-mldsa.md
+++ b/draft-ietf-tls-mldsa.md
@@ -115,10 +115,6 @@ The corresponding end-entity
 certificate MUST use the corresponding AlgorithmIdentifier
 from {{schemes}} in its SubjectPublicKeyInfo.
 
-The context parameter defined in {{FIPS204}} Algorithm 2 and 3
-MUST be the empty string. Note that the context parameter of FIPS 204
-is different from the context string of {{Section 4.4.3 of RFC8446}}.
-
 # Security Considerations
 
 The security considerations described in {{Appendices C.2 and E.1 of RFC8446}}


### PR DESCRIPTION
This is a tiny editorial cleanup after -04.

The Handshake Signature section already states that the FIPS 204 `ctx` parameter MUST be the empty string and explains that it is different from the TLS 1.3 CertificateVerify context string. The same note appears again immediately after the end-entity certificate AlgorithmIdentifier sentence.

This PR removes the duplicate second occurrence only. It does not change the normative requirement.

Validation:

- `git diff --check` passes.
- `make` passes locally: kramdown-rfc, xml2rfc txt, and xml2rfc html all completed successfully.
